### PR TITLE
Update to version 9.0.2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,12 @@
 FROM phusion/baseimage:latest
 MAINTAINER Jochen Breuer "brejoc@gmail.com"
 RUN apt-get -y update
-RUN apt-get -y upgrade
 RUN apt-get install -y apache2 php5 php5-gd php-xml-parser php5-intl php5-mysqlnd php5-json php5-mcrypt php5-sqlite smbclient curl libcurl3 php5-curl bzip2 wget
 RUN apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
 RUN rm -rf /etc/service/sshd /etc/my_init.d/00_regen_ssh_host_keys.sh
 
-RUN curl -k https://download.owncloud.org/community/owncloud-8.2.2.tar.bz2 | tar jx -C /var/www/
+RUN curl -k https://download.owncloud.org/community/owncloud-9.0.2.tar.bz2 | tar jx -C /var/www/
 RUN mkdir /var/www/owncloud/data
 RUN chown -R www-data:www-data /var/www/owncloud
 RUN chmod 770 -R /var/www/owncloud/data


### PR DESCRIPTION
Major update to ownCloud version 9.0.2.

Also removed `apt-get update` since the latest phusion base-image (0.9.18)
fixed "CVE-2015-3193 and a few others": https://github.com/phusion/baseimage-docker/blob/master/Changelog.md#0918-release-date-2015-12-08
