### PR TITLE
Pinning basimage version to 0.9.15

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM phusion/baseimage:latest
+FROM phusion/baseimage:0.9.15
 MAINTAINER Jochen Breuer "brejoc@gmail.com"
 RUN apt-get -y update
 RUN apt-get install -y apache2 php5 php5-gd php-xml-parser php5-intl php5-mysqlnd php5-json php5-mcrypt php5-sqlite smbclient curl libcurl3 php5-curl bzip2 wget


### PR DESCRIPTION
We are expecting an Ubuntu 14.04 and the latest version of phusion/baseimage seems to be based on Ubuntu 16.04. For now are are just pinning to the old version.
